### PR TITLE
Fix memory leak

### DIFF
--- a/seir.py
+++ b/seir.py
@@ -103,6 +103,32 @@ def developing_step(key, state, state_timer, recovery_probabilities,
           state * (1 - to_develop) + new_state * to_develop,
           state_timer * (1 - to_develop) + new_state_timer * to_develop)
 
+
+def eval_fn(t, state, state_timer, states_cumulative, history):
+  del t, state_timer
+  history.append([np.mean(to_one_hot(state), axis=0),
+                  np.mean(states_cumulative, axis=0)])
+  return history
+
+
+@functools.partial(jit, static_argnums=(2,))
+def step(t, args, state_length_sampler):
+  del t
+  w, key, state, state_timer, states_cumulative, infection_probabilities, recovery_probabilities = args
+
+  interaction_step_ = interaction_step  
+  if isinstance(w, list):
+    interaction_step_ = sparse_interaction_step
+ 
+  key, state, state_timer = interaction_step_(
+      key, state, state_timer, w, infection_probabilities,
+      state_length_sampler)
+  key, state, state_timer = developing_step(
+      key, state, state_timer, recovery_probabilities, state_length_sampler)
+  states_cumulative = np.logical_or(to_one_hot(state), states_cumulative)
+  return w, key, state, state_timer, states_cumulative, infection_probabilities, recovery_probabilities
+
+
 def simulate(w, total_steps, state_length_sampler, infection_probabilities,
              recovery_probabilities, init_state, init_state_timer, key=0,
              epoch_len=1, states_cumulative=None):
@@ -161,33 +187,11 @@ def simulate(w, total_steps, state_length_sampler, infection_probabilities,
 
   if isinstance(key, int):
     key = random.PRNGKey(key)
-  
-  interaction_step_ = interaction_step
-  if isinstance(w, list):
-    interaction_step_ = sparse_interaction_step
 
   if isinstance(total_steps, tuple):
     total_steps, break_fn = total_steps
   else:
     break_fn = lambda *args, **kwargs: False
-  
-  def eval_fn(t, state, state_timer, states_cumulative, history):
-    del t, state_timer
-    history.append([np.mean(to_one_hot(state), axis=0),
-                    np.mean(states_cumulative, axis=0)])
-    return history
-  
-  @jit
-  def step(t, args):
-    del t
-    key, state, state_timer, states_cumulative = args
-    key, state, state_timer = interaction_step_(
-        key, state, state_timer, w, infection_probabilities,
-        state_length_sampler)
-    key, state, state_timer = developing_step(
-        key, state, state_timer, recovery_probabilities, state_length_sampler)
-    states_cumulative = np.logical_or(to_one_hot(state), states_cumulative)
-    return key, state, state_timer, states_cumulative
 
   state, state_timer = init_state, init_state_timer
   if states_cumulative is None:
@@ -196,9 +200,12 @@ def simulate(w, total_steps, state_length_sampler, infection_probabilities,
 
   epochs = int(total_steps // epoch_len)
   history = []
+  
   for epoch in tqdm.tqdm(range(epochs), total=epochs, position=0):
-    key, state, state_timer, states_cumulative = fori_loop(
-        0, epoch_len, step, (key, state, state_timer, states_cumulative))
+    val = (w, key, state, state_timer, states_cumulative, infection_probabilities, recovery_probabilities)
+    for i in range(0, epoch_len):
+      val = step(i, val, state_length_sampler)
+    w, key, state, state_timer, states_cumulative, infection_probabilities, recovery_probabilities = val
     history = eval_fn(
         epoch*epoch_len, state, state_timer, states_cumulative, history)
     if break_fn(


### PR DESCRIPTION
- move step(...) and eval_fn(...) outside the scope of simulate(...)
- since state_length_sampler is a function, it has to be passed with static_argnums to the jitted step(...) function; for this, we need to also expand the fori_loop such that we can pass a 3rd argument to step(...)
- also need to explicitly pass a few other arguments (w, infection_probabilities, recovery_probabilities) to the step(...) function

I checked and this solves all memory leak issues (one way to check is by setting %env XLA_PYTHON_CLIENT_ALLOCATOR=platform, so that the GPU memory is allocated on a need by basis (note that this can be slower than the default method) and then use GPUtil functions to get the GPU usage).